### PR TITLE
move things around

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,10 +5,4 @@ let
   };
   pkgs = import tarball { };
 in
-
-pkgs.dockerTools.buildImage {
-  name = "hello-docker";
-  config = {
-    Cmd = [ "${pkgs.hello}/bin/hello" ];
-  };
-}
+pkgs

--- a/derivation-hello/builder.sh
+++ b/derivation-hello/builder.sh
@@ -1,0 +1,9 @@
+source $stdenv/setup
+
+PATH=$perl/bin:$PATH
+
+tar xvfz $src
+cd hello-*
+./configure --prefix=$out
+make
+make install

--- a/derivation-hello/default.nix
+++ b/derivation-hello/default.nix
@@ -1,0 +1,12 @@
+let
+  pkgs = import ./..;
+in
+pkgs.stdenv.mkDerivation {
+  name = "hello-2.1.1";
+  builder = ./builder.sh;
+  src = pkgs.fetchurl {
+    url = "ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz";
+    sha256 = "1md7jsfd8pa45z73bz1kszpp01yw6x5ljkjk2hx7wl800any6465";
+  };
+  perl = pkgs.perl;
+}

--- a/docker-hello/default.nix
+++ b/docker-hello/default.nix
@@ -1,0 +1,10 @@
+let
+  pkgs = import ./..;
+in
+
+pkgs.dockerTools.buildImage {
+  name = "hello-docker";
+  config = {
+    Cmd = [ "${pkgs.hello}/bin/hello" ];
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,5 @@
 let
-  tarball = fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/bdac72d387dca7f836f6ef1fe547755fb0e9df61.tar.gz";
-    sha256 = "sha256:1kyxarhs7g80ixlcddxw2fbs24zqb250hkyb8wv9xz8hs869n2si";
-  };
-  pkgs = import tarball { };
+  pkgs = import ./.;
 in
 
 pkgs.mkShellNoCC {


### PR DESCRIPTION
Not very idiomatic, but might be easier to understand than `callPackage` and functions? To build you `cd directory && nix-build`.

The alternative would be #3. What do you think?